### PR TITLE
:horse: Dockefileの改善、apiルーティング中のクロージャを削除

### DIFF
--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -22,9 +22,13 @@ RUN curl -sS https://getcomposer.org/installer | php && \
   mv composer.phar /usr/local/bin/composer && \
   chmod +x /usr/local/bin/composer
 
-
+COPY ./src/database /var/www/html/database
+COPY ./src/tests /var/www/html/tests
+COPY ./src/composer.* /var/www/html/
+RUN composer install --no-scripts
 COPY ./src /var/www/html
-RUN composer install
+RUN php artisan clear-compiled
+RUN php artisan optimize
 
 COPY ./docker/php-fpm/php.ini /usr/local/etc/php/
 

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -14,12 +14,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('api')->get('/user', function (Request $request) {
-    return $request->user();
-});
 Route::get('/forums{forum_id}', 'ForumController@get_forum')->name('forums.get_forum');
 Route::get('/forums', 'ForumController@list')->name('forums.list');
 Route::post('/forums', 'ForumController@create')->name('forums.create');
-Route::get('/test', function (Request $request) {
-    return response()->json(['message' => 'success'], 200);
-});


### PR DESCRIPTION
ソース変更のたびにcomposer installしないように変更。
それに伴い、artisan route:cache 実行時にルーティング中にクロージャがある場合はキャッシュできないとのエラーが発生するため、該当処理を削除。